### PR TITLE
Add maven configuration

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,14 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        mavenLocal()
+        maven {
+            name = "KMMBridgeKickStart"
+            url = uri(TODO("You must add your package url here. For github packages it will look like \"https://maven.pkg.github.com/{YOUR_ORG}/{YOUR_REPO}\""))
+            credentials {
+                username = TODO("You must add your github username here")
+                password = TODO("You must add your github personal access token here")
+            }
+        }
     }
 }
 rootProject.name = "KMMBridgeKickStart-Android"


### PR DESCRIPTION
Adds a configuration for a maven repository pointing to where you've published your android artifacts. You will need to update the url and credentials accordingly. Credentials with at least package:read permissions are required regardless of whether your library repo is public or private. see [documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-to-github-packages)